### PR TITLE
exclude OTP 17.0 test for Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         otp: ['17.0', '20.0', '23.0-rc3', '21.3.8.18']
         os: ['ubuntu-20.04', 'ubuntu-18.04', 'ubuntu-latest', 'ubuntu-16.04']
+        exclude: [{os: ubuntu-20.04, otp: '17.0'}]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Old versions of OTP are not available for Ubuntu 20.04 any more
https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt